### PR TITLE
fix Drop-down menu on the navbar doesn't close on double click

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -240,11 +240,16 @@
 
     dropdownButtons.forEach(function (dropdownButton) {
       dropdownButton.addEventListener("click", function () {
-        if (currentlyOpenDropdown) {
+        if (currentlyOpenDropdown === this.nextElementSibling) {
+          currentlyOpenDropdown.classList.toggle("hidden");
+          currentlyOpenDropdown = null;
+        } else {
+          if (currentlyOpenDropdown) {
+            currentlyOpenDropdown.classList.toggle("hidden");
+          }
+          currentlyOpenDropdown = this.nextElementSibling;
           currentlyOpenDropdown.classList.toggle("hidden");
         }
-        currentlyOpenDropdown = this.nextElementSibling;
-        currentlyOpenDropdown.classList.toggle("hidden");
       });
     });
 


### PR DESCRIPTION
fix the Drop-down menu on the navbar doesn't close on double-click
[Screencast from 22-10-23 07:23:01 PM IST.webm](https://github.com/centerofci/mathesar-website/assets/92110858/41b33077-64eb-4bab-8af9-2e8f747e35b4)

Closes #91 
