### PR TITLE
Redirect /donate to /sponsor.html

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ group :jekyll_plugins do
   gem 'jekyll-postcss-v2'
   gem 'jekyll-sitemap'
   gem 'jekyll-seo-tag'
+  gem 'jekyll-redirect-from'
 end
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -300,6 +300,7 @@ DEPENDENCIES
   http_parser.rb (~> 0.6.0)
   jekyll-feed (~> 0.12)
   jekyll-postcss-v2
+  jekyll-redirect-from
   jekyll-seo-tag
   jekyll-sitemap
   minima (~> 2.5)

--- a/sponsor.md
+++ b/sponsor.md
@@ -2,6 +2,8 @@
 layout: default
 title: Sponsor Mathesar - Mathesar
 description: Sponsor Mathesar
+redirect_from:
+  - /donate/
 ---
 
 {% capture header %}


### PR DESCRIPTION

Fixes #114

This is to support our [In-app donation](https://app.asana.com/0/1208419327178360/1208362584915899) feature.

