### PR TITLE
Remove demo references

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -69,14 +69,6 @@
           </div>
           <a
             class="navigation-item"
-            href="https://demo.mathesar.org/"
-            target="_blank"
-            aria-label="Live Demo (opens in new tab)"
-          >
-            <span>Live Demo</span>
-          </a>
-          <a
-            class="navigation-item"
             href="https://docs.mathesar.org/"
             target="_blank"
             aria-label="Docs (opens in new tab)"
@@ -208,13 +200,6 @@
               class="text-lg whitespace-nowrap hover:underline"
               href="{{ 'blog' | relative_url }}"
               >Blog</a
-            >
-            <a
-              class="text-lg whitespace-nowrap hover:underline"
-              href="https://demo.mathesar.org/"
-              target="_blank"
-              aria-label="Live Demo (opens in new tab)"
-              >Live Demo</a
             >
             <a class="text-lg whitespace-nowrap hover:underline" href="faq.html"
               >FAQ</a

--- a/non-technical-expert.md
+++ b/non-technical-expert.md
@@ -14,7 +14,6 @@ No technical skills required.
 
 {% capture actions %}
 {% include button.html style="primary" label="Stay updated on our cloud release" url="#signup-form" %}
-{% include button.html style="secondary" label="Play with Live Demo" external=true url="https://demo.mathesar.org" %}
 {% endcapture %}
 
 {% include hero.html

--- a/software-engineer.md
+++ b/software-engineer.md
@@ -14,7 +14,6 @@ Now you can spend **less time** creating custom reports and manually updating da
 
 {% capture actions %}
 {% include button.html style="primary" label="Install Mathesar" external=true url="https://docs.mathesar.org" %}
-{% include button.html style="secondary" label="Play with Live Demo" external=true url="https://demo.mathesar.org" %}
 {% endcapture %}
 
 {% include hero.html


### PR DESCRIPTION
This PR removes references to demo.mathesar.org in the website. It does **not** remove demo links from inline text in blog posts. There is only one of these at `_posts/2024-03-15-live-stream-on-github-open-source-friday.md`.

We should decide on an approach for redirecting or hosting a simple splash page on demo.mathesar.org indicating that the demo no longer exists.