### PR TITLE
Add /survey route and redirect to google forms survey page

### DIFF
--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -149,7 +149,7 @@
             Share your thoughts in our quick survey:
           </p>
           <a
-            href="https://forms.gle/yjxiEQr9QzTT5GCSA"
+            href="/survey"
             target="_blank"
             rel="noopener noreferrer"
             class="w-full block text-center bg-plum-300/20 text-plum-800 border-2 border-plum-500 hover:bg-plum-400/20 px-4 py-2 rounded-lg font-medium transition-colors duration-300 flex items-center justify-center gap-1"

--- a/src/routes/survey/+page.server.ts
+++ b/src/routes/survey/+page.server.ts
@@ -1,0 +1,7 @@
+import { redirect } from "@sveltejs/kit";
+
+const SURVEY_FORM_LINK = "https://forms.gle/yjxiEQr9QzTT5GCSA";
+
+export async function load() {
+  redirect(301, SURVEY_FORM_LINK);
+}


### PR DESCRIPTION
I'm adding a link to the survey page in the feedback form within Mathesar in https://github.com/mathesar-foundation/mathesar/pull/4241.

Since we need to hardcode the url in the product, I'm adding the `/survey` route in the website. Currently this route redirects all requests to the google form we have.